### PR TITLE
Fix research prerequisites and apparel body part assignments

### DIFF
--- a/Defs/Apparel/Collars.xml
+++ b/Defs/Apparel/Collars.xml
@@ -63,10 +63,10 @@
     <colorGenerator Class="ColorGenerator_StandardApparel" />
     <recipeMaker>
       <displayPriority>176</displayPriority>
-    </recipeMaker>
       <researchPrerequisites>
           <li>PRPuppy</li>
       </researchPrerequisites>
+    </recipeMaker>
   </ThingDef>
 
     <ThingDef ParentName="HatMakeableBase">
@@ -132,10 +132,10 @@
     <colorGenerator Class="ColorGenerator_StandardApparel" />
     <recipeMaker>
       <displayPriority>177</displayPriority>
-    </recipeMaker>
       <researchPrerequisites>
           <li>PRKitten</li>
       </researchPrerequisites>
+    </recipeMaker>
   </ThingDef>
 
       <ThingDef ParentName="HatMakeableBase">
@@ -201,10 +201,10 @@
     <colorGenerator Class="ColorGenerator_StandardApparel" />
     <recipeMaker>
       <displayPriority>178</displayPriority>
-    </recipeMaker>
       <researchPrerequisites>
           <li>PRCow</li>
       </researchPrerequisites>
+    </recipeMaker>
   </ThingDef>
 
         <ThingDef ParentName="HatMakeableBase">
@@ -236,7 +236,7 @@
       <slaveApparel>true</slaveApparel>
       <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <bodyPartGroups>
-        <li>Head</li>
+        <li>Neck</li>
       </bodyPartGroups>
       <wornGraphicPath>Apearal/Doll/DollCollar/DollCollar</wornGraphicPath>
       <layers>
@@ -269,10 +269,10 @@
     <colorGenerator Class="ColorGenerator_StandardApparel" />
     <recipeMaker>
       <displayPriority>178</displayPriority>
-    </recipeMaker>
       <researchPrerequisites>
           <li>PRDoll</li>
       </researchPrerequisites>
+    </recipeMaker>
   </ThingDef>
 
 </Defs>

--- a/Defs/Apparel/HeadwearExtras.xml
+++ b/Defs/Apparel/HeadwearExtras.xml
@@ -40,9 +40,11 @@
     <tradeTags>
       <li>BasicClothing</li>
     </tradeTags>
+    <recipeMaker>
       <researchPrerequisites>
           <li>PRKitten</li>
       </researchPrerequisites>
+    </recipeMaker>
   </ThingDef>
 
     <HediffDef>
@@ -162,7 +164,10 @@
       <SlaveSuppressionOffset MayRequire="Ludeon.RimWorld.Ideology">0.05</SlaveSuppressionOffset>
     </equippedStatOffsets>
     <recipeMaker>
-      <researchPrerequisite>Machining</researchPrerequisite>
+      <researchPrerequisites>
+        <li>Machining</li>
+        <li>PRPuppy</li>
+      </researchPrerequisites>
       <unfinishedThingDef>UnfinishedMask</unfinishedThingDef>
       <recipeUsers Inherit="False">
         <li>TableMachining</li>
@@ -199,9 +204,6 @@
         <part>Head</part>
       </li>
     </comps>
-        <researchPrerequisites>
-          <li>PRPuppy</li>
-      </researchPrerequisites>
   </ThingDef>
 
   <ThingDef ParentName="HatMakeableBase">
@@ -228,7 +230,10 @@
       <SlaveSuppressionOffset MayRequire="Ludeon.RimWorld.Ideology">0.05</SlaveSuppressionOffset>
     </equippedStatOffsets>
     <recipeMaker>
-      <researchPrerequisite>Machining</researchPrerequisite>
+      <researchPrerequisites>
+        <li>Machining</li>
+        <li>PRPuppy</li>
+      </researchPrerequisites>
       <unfinishedThingDef>UnfinishedMask</unfinishedThingDef>
       <recipeUsers Inherit="False">
         <li>TableMachining</li>
@@ -265,9 +270,6 @@
         <part>Head</part>
       </li>
     </comps>
-        <researchPrerequisites>
-          <li>PRPuppy</li>
-      </researchPrerequisites>
   </ThingDef>
 
     <HediffDef>
@@ -390,7 +392,10 @@
       <SlaveSuppressionOffset MayRequire="Ludeon.RimWorld.Ideology">0.15</SlaveSuppressionOffset>
     </equippedStatOffsets>
     <recipeMaker>
-      <researchPrerequisite>Machining</researchPrerequisite>
+      <researchPrerequisites>
+        <li>Machining</li>
+        <li>PRDoll</li>
+      </researchPrerequisites>
       <unfinishedThingDef>UnfinishedMask</unfinishedThingDef>
       <recipeUsers Inherit="False">
         <li>TableMachining</li>
@@ -422,9 +427,6 @@
         <part>Head</part>
       </li>
     </comps>
-        <researchPrerequisites>
-          <li>PRDoll</li>
-      </researchPrerequisites>
   </ThingDef>
 
     <HediffDef>
@@ -570,9 +572,11 @@
     <tradeTags>
       <li>BasicClothing</li>
     </tradeTags>
-        <researchPrerequisites>
+    <recipeMaker>
+      <researchPrerequisites>
           <li>PRCow</li>
       </researchPrerequisites>
+    </recipeMaker>
   </ThingDef>
 
     <HediffDef>

--- a/Defs/BDSM Gear/Weapons.xml
+++ b/Defs/BDSM Gear/Weapons.xml
@@ -26,6 +26,9 @@
       <li>Woody</li>
     </stuffCategories>
     <recipeMaker>
+      <researchPrerequisites>
+        <li>PRPuppy</li>
+      </researchPrerequisites>
       <recipeUsers>
         <li>CraftingSpot</li>
       </recipeUsers>
@@ -43,9 +46,6 @@
         <chanceFactor>200</chanceFactor>
       </li>
     </tools>
-        <researchPrerequisites>
-          <li>PRPuppy</li>
-      </researchPrerequisites>
   </ThingDef>
 
       <ThingDef ParentName="BaseMeleeWeapon_Blunt">
@@ -74,6 +74,9 @@
       <li>Woody</li>
     </stuffCategories>
     <recipeMaker>
+      <researchPrerequisites>
+        <li>PRKitten</li>
+      </researchPrerequisites>
       <recipeUsers>
         <li>CraftingSpot</li>
       </recipeUsers>
@@ -91,9 +94,6 @@
         <chanceFactor>200</chanceFactor>
       </li>
     </tools>
-      <researchPrerequisites>
-          <li>PRKitten</li>
-      </researchPrerequisites>
   </ThingDef>
 
       <ThingDef ParentName="BaseMeleeWeapon_Blunt">
@@ -122,6 +122,9 @@
       <li>Leathery</li>
     </stuffCategories>
     <recipeMaker>
+      <researchPrerequisites>
+        <li>PRCow</li>
+      </researchPrerequisites>
       <recipeUsers>
         <li>CraftingSpot</li>
       </recipeUsers>
@@ -139,9 +142,6 @@
         <chanceFactor>200</chanceFactor>
       </li>
     </tools>
-      <researchPrerequisites>
-          <li>PRCow</li>
-      </researchPrerequisites>
   </ThingDef>
 
       <ThingDef ParentName="BaseMeleeWeapon_Blunt">
@@ -170,6 +170,9 @@
       <li>Leathery</li>
     </stuffCategories>
     <recipeMaker>
+      <researchPrerequisites>
+        <li>PRDoll</li>
+      </researchPrerequisites>
       <recipeUsers>
         <li>CraftingSpot</li>
       </recipeUsers>
@@ -187,9 +190,6 @@
         <chanceFactor>200</chanceFactor>
       </li>
     </tools>
-      <researchPrerequisites>
-          <li>PRDoll</li>
-      </researchPrerequisites>
   </ThingDef>
 
       <ThingDef ParentName="BaseMeleeWeapon_Blunt">
@@ -219,6 +219,9 @@
       <li>Metallic</li>
     </stuffCategories>
     <recipeMaker>
+      <researchPrerequisites>
+        <li>PRDoll</li>
+      </researchPrerequisites>
       <recipeUsers>
         <li>CraftingSpot</li>
       </recipeUsers>
@@ -236,9 +239,5 @@
         <chanceFactor>200</chanceFactor>
       </li>
     </tools>
-      <researchPrerequisites>
-          <li>PRDoll</li>
-      </researchPrerequisites>
   </ThingDef>
-
 </Defs>


### PR DESCRIPTION
- Move research prerequisites inside recipeMaker tags for proper application
- Apply research requirements to mask recipes for machining table
- Apply research requirements to cat and cow ear recipes
- Fix weapons research requirements
- Fix doll collar to target Neck instead of Head body part group